### PR TITLE
Add "<sup>A" (6.7.10) comment for EM3581

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ __Folders containing different versions of bootloader and NCP firmware.__
 * EFR32MG2x-768k <sup>B  
 * EFR32MG22 <sup>B
 * EM357     <sup>A
-* EM3581
+* EM3581    <sup>A
 * EM3585    <sup>A
 * EM3587    <sup>A
 * EM3588    <sup>A


### PR DESCRIPTION
Add "<sup>A" comment for EM3581 to indicate EmberZNet 6.7.10 (6.7.10.3?)